### PR TITLE
security review

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ The `contextMessage` is optional.  If given, both alice and bob must use the sam
 
 ## Security Review
 
-first an ephemeral key is generated, and stored on the local system for later, under an arbitary
+First an ephemeral key is generated, and stored on the local system for later, under an arbitrary
 key that the user selects. (since ssb is a async system for non-realtime communication it's necessary to store the ephemeral keys)
 
 All keys are `curve25519` type.
 
-### encryption
+### Encryption
 
 A `message` is encrypted to a `recipientEphemeralKey` with a `contextMessage`.
 The `contextMessage` serves to prevent ephemeral messages intended for one purpose
@@ -75,16 +75,16 @@ then that is used to encrypt the message:
 cyphertext = secretbox(message, nonce, sharedSecret)
 ```
 
-the `sharedSecret` and `singleUseKey` are zerod,
+The `sharedSecret` and `singleUseKey` are zerod,
 and `nonce + singeUseKey.public + cyphertext` is returned.
 
-### decryption
+### Decryption
 
 The user has to know which stored ephemeral key is to be used.
-probably the stored key should be identified with a message id,
+Probably the stored key should be identified with a message id,
 since they will need to post it to another peer so that they may encrypt to it.
 
-to decrypt, the user receives
+To decrypt, the user receives
 
 ``` js
   ephemeral_message = nonce + singeUseKey.public + cyphertext
@@ -102,7 +102,7 @@ sharedSecret = hash(
 ```
 and then that is used to decrypt the key.
 
-### comments on security
+### Comments on security
 
 Although there is nothing wrong with the crypto operations used in this library,
 It only solves half the problem, and leaves quite a bit of the responsibility of


### PR DESCRIPTION
I was assigned https://github.com/ssbc/ssb-ephemeral-keys/issues/3 by in the village-issue-tracker experiment, but I decided that we needed a security review much more, so I did that instead.

So I have documented the encryption, and also posted several issues and comments.

I think ssb-ephemeral-keys needs to make a much stronger recommendation about the correct way to use this. As it is, there is considerable expectation put on the application using this to use it in a secure way, that means the application needs to be audited... (for example, does the application delete the key at the right time, does it create new ephemeral keys at the right time, does it not reuse contextMessages etc)

I think it would be far better if ssb-ephemeral-keys handled everything, and applications had to really go out of their way to use it unsecurely. For example, restrict use to a private thread, and given a thread, allow posting a recipient key to it, then that allows your peer to post an encrypted ephemeral message to it.
when that is received, publish a message in the thread acknowledging that and that you have deleted the ephemeral key.