### PR TITLE
Hash all db keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,42 @@ sbot.ephemeral.generateAndStore(dbKey, (err, pk) => {
 
 Note that both alice and bob must use the same context message.
 
+## API
+
+### `generateAndStore(databaseKey, callback)` (async)
+
+This function will generate a keypair, store the secret key
+to disk, indexed by the given database key and return
+the public key to be included in a request in the callback.
+
+databaseKey may be a string or an object
+
+### `boxMessage(message, recipientPublicKey, contextMessage, cb)` (async)
+
+This function will generate a keypair, encrypt a given shard to
+a given ephemeral public key, delete the generated private key, 
+and return the encrypted message encoded as a base64 string in the callback.
+ 
+The context message is a string which is added to the shared
+secret so that it may only be used for a specific purpose.
+
+### `unBoxMessage(databaseKey, encryptedMessage, contextMessage, callback)` (async)
+
+This function will grab a stored secret key from disk using the
+given database key, use it to decrypt a given message and return the
+result in the callback.
+
+The context message is a string which is added to the shared
+secret so that it may only be used for a specific purpose.
+
+databaseKey may be a string or an object
+
+### `deleteKeyPair(databaseKey, callback)` (async)
+
+This function will delete a keyPair identified by the given database key
+
+databaseKey may be a string or an object
+
 ## Security Review
 
 First an ephemeral key is generated, and stored on the local system for later, under an arbitrary
@@ -109,40 +145,4 @@ It only solves half the problem, and leaves quite a bit of the responsibility of
 implementing a secure system to the application which uses it. That is to say,
 it's would be easy for the application to screw things up. For example,
 by not deleting the key, or reusing the key too many times.
-
-## API
-
-### `generateAndStore(databaseKey, callback)` (async)
-
-This function will generate a keypair, store the secret key
-to disk, indexed by the given database key and return
-the public key to be included in a request in the callback.
-
-databaseKey may be a string or an object
-
-### `boxMessage(message, recipientPublicKey, contextMessage, cb)` (async)
-
-This function will generate a keypair, encrypt a given shard to
-a given ephemeral public key, delete the generated private key, 
-and return the encrypted message encoded as a base64 string in the callback.
- 
-The context message is a string which is added to the shared
-secret so that it may only be used for a specific purpose.
-
-### `unBoxMessage(databaseKey, encryptedMessage, contextMessage, callback)` (async)
-
-This function will grab a stored secret key from disk using the
-given database key, use it to decrypt a given message and return the
-result in the callback.
-
-The context message is a string which is added to the shared
-secret so that it may only be used for a specific purpose.
-
-databaseKey may be a string or an object
-
-### `deleteKeyPair(databaseKey, callback)` (async)
-
-This function will delete a keyPair identified by the given database key
-
-databaseKey may be a string or an object
 

--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ module.exports = {
     function generateAndStore (dbKey, callback) {
       const ephKeypairBuffer = keyPair()
       var ephKeypair = {}
-
+      // TODO: check that there does not already exist a keypair with this key
       for (var k in ephKeypairBuffer) ephKeypair[k] = packKey(ephKeypairBuffer[k])
-
+      assert(dbKey, 'A database key must be given')
       fs.writeFile(buildFileName(dbKey), JSON.stringify(ephKeypair, null, 2), (err) => {
         if (err) return callback(err)
         callback(null, ephKeypair.publicKey)
@@ -58,6 +58,7 @@ module.exports = {
         return callback(new Error('Ciphertext must end in ' + cipherTextSuffix))
       }
 
+      assert(dbKey, 'A database key must be given')
       fs.readFile(buildFileName(dbKey), (err, data) => {
         if (err) return callback(err)
         const ephKeypairBase64 = JSON.parse(data)
@@ -79,6 +80,7 @@ module.exports = {
     }
 
     function deleteKeyPair (dbKey, callback) {
+      assert(dbKey, 'A database key must be given')
       skrub([ buildFileName(dbKey) ], {dryRun: false}).then(
         paths => { callback() },
         err => callback(err)

--- a/index.js
+++ b/index.js
@@ -86,16 +86,14 @@ module.exports = {
       )
     }
 
-    function buildFileName (fileName) {
-      if (isMsg(fileName)) {
-        fileName = Buffer.from(fileName.split('.')[0], 'base64').toString('hex')
+    function buildFileName (dbKey) {
+      if (isObject(dbKey)) {
+        dbKey = JSON.stringify(dbKey)
       }
-      if (isObject(fileName)) {
-        // Stringify, then take hash and encode as hex
-        fileName = genericHash(Buffer.from(JSON.stringify(fileName))).toString('hex')
-      }
-      fileName += '.json'
-      return join(config.path, dbPath, fileName)
+      // to obfuscate the chosen dbKey on disk, the filename is it's hash
+      const fileName = genericHash(Buffer.from(dbKey)).toString('hex')
+      console.log(fileName)
+      return join(config.path, dbPath, fileName + '.json')
     }
 
     return {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,6 @@ module.exports = {
       }
       // to obfuscate the chosen dbKey on disk, the filename is it's hash
       const fileName = genericHash(Buffer.from(dbKey)).toString('hex')
-      console.log(fileName)
       return join(config.path, dbPath, fileName + '.json')
     }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const mkdirp = require('mkdirp')
 const { join } = require('path')
 const fs = require('fs')
 const skrub = require('skrub')
-const { isMsg } = require('ssb-ref')
 
 const { assert, isString, isObject } = require('./util')
 const curve = 'curve25519'


### PR DESCRIPTION
any database key should be hashed before using it as a filename to obfuscate potentially sensitive data being exposed on disk.

this has the added advantage of allowing database keys be of arbitrary length and type and contain characters not normally allowed in filenames